### PR TITLE
Send custom data in payload

### DIFF
--- a/wp-parse-api.php
+++ b/wp-parse-api.php
@@ -111,8 +111,13 @@ class WpParseApi
 					$push = new parsePush();
 					$push->alert = $post->data['title'];
 					$push->channels = $categories;
-					$push->send();
-				} catch (Exception $e) {
+					$push->badge = "increment";
+					$push->sound = "example.caf";
+					$push->post_id = $post->data[wpId];
+					$push->url = $post->data['guid'];
+					$push->category = "ACTIONABLE";
+					$push->send();				} 
+					catch (Exception $e) {
 					// do nothing, this was added because 
 					// parse lib throws an exception if the account
 					// has not been configured


### PR DESCRIPTION
I 've change the code to send custom data in payload !
In this way i can send notification with custom sound and badge , post-id o url to open directly the post from notification and category to handle custom actionable notification !
In this case post_id and url are sensed outside the aps dictionary and it's work perfectly !
This is an example of the resulted payload 

{
    aps { 
           "alert": "titolo",
           "badge": "increment",
           "category": "ACTIONABLE",  
           "sound": "example.caf" 
           }
          "url": "http://example.com/?p=12345",
          "post_id": 12345
}