### PR TITLE
Added option to point to different parser-server instances

### DIFF
--- a/includes/class-wp-parse-api-admin-settings-template.php
+++ b/includes/class-wp-parse-api-admin-settings-template.php
@@ -31,6 +31,10 @@ if (!current_user_can('manage_options')) {
 				<td><input type="text" name="app_restkey" value="<?php echo get_option('app_restkey'); ?>"></td>
 			</tr>
 			<tr valign="top">
+				<th  scope="row">App URL (https://&#60;yoururl&#62;/&#60;yourendpoint&#62;)</th>
+				<td><input type="text" name="app_url" value="<?php echo get_option('app_url'); ?>"></td>
+			</tr>
+			<tr valign="top">
 				<th  scope="row">Push notifications</th>
 				<td>
 					<select name="app_push_notifications">

--- a/includes/class-wp-parse-api-admin-settings.php
+++ b/includes/class-wp-parse-api-admin-settings.php
@@ -15,6 +15,7 @@ if (is_admin()){	 // admin actions
 		register_setting('wp-parse-api-settings-group', 'app_id');
 		register_setting('wp-parse-api-settings-group', 'app_masterkey');
 		register_setting('wp-parse-api-settings-group', 'app_restkey');
+		register_setting('wp-parse-api-settings-group', 'app_url');
 		register_setting('wp-parse-api-settings-group', 'app_push_notifications');
 		register_setting('wp-parse-api-settings-group', 'object_name');
 		register_setting('wp-parse-api-settings-group', 'lang');

--- a/libs/parse.com-php-library/parseConfig.php
+++ b/libs/parse.com-php-library/parseConfig.php
@@ -2,11 +2,12 @@
 if (!defined('WP_PARSE_API_APP_ID'))		define('WP_PARSE_API_APP_ID'		, get_option('app_id'));
 if (!defined('WP_PARSE_API_MASTERKEY'))		define('WP_PARSE_API_MASTERKEY'		, get_option('app_masterkey'));
 if (!defined('WP_PARSE_API_APP_RESTKEY'))	define('WP_PARSE_API_APP_RESTKEY'	, get_option('app_restkey'));
+if (!defined('WP_PARSE_API_APP_URL'))	define('WP_PARSE_API_APP_URL'	, get_option('app_url'));
 if (!defined('WP_PARSE_API_OBJECT_NAME'))	define('WP_PARSE_API_OBJECT_NAME'	, get_option('object_name') == "" ? 'Post' : get_option('object_name'));
 
 class parseConfig {
 	var $APPID = WP_PARSE_API_APP_ID;
 	var $MASTERKEY = WP_PARSE_API_MASTERKEY;
 	var $RESTKEY = WP_PARSE_API_APP_RESTKEY;
-	var $PARSEURL = 'https://api.parse.com/1/';
+	var $PARSEURL = WP_PARSE_API_APP_URL;
 }


### PR DESCRIPTION
Like the commit message says, allow the user to configure their own parse-server url so that they can point to their own self-hosted instance. Tested with a parse-server instance deployed using the guide found [here](https://devcenter.heroku.com/articles/deploying-a-parse-server-to-heroku). Changing the url in the config file does the same thing, but I thought it would be nice for users to plug-and-play without having to modify before upload. See below for test completion evidence.
![test-ev1](https://cloud.githubusercontent.com/assets/13068221/16875955/095dfa06-4a70-11e6-80d2-7547d7a114b3.png)
![test-ev2](https://cloud.githubusercontent.com/assets/13068221/16875957/0cac7214-4a70-11e6-9817-87d305d64e13.png)
![test-ev3](https://cloud.githubusercontent.com/assets/13068221/16876027/59df8a30-4a70-11e6-84b9-8f936248d880.png)
